### PR TITLE
Fix `<target-triple>-ranlib` command not found

### DIFF
--- a/native_toolchain_rust/lib/src/build_environment.dart
+++ b/native_toolchain_rust/lib/src/build_environment.dart
@@ -83,6 +83,7 @@ interface class AndroidBuildEnvironmentFactory {
     const apiTarget = '35';
     final clangPath = getCompilerPath('$ndkTargetTriple$apiTarget-clang');
     final clangPpPath = getCompilerPath('$ndkTargetTriple$apiTarget-clang++');
+    final ranlibPath = getCompilerPath('llvm-ranlib');
 
     final ndkToolchainRoot = path.dirname(path.dirname(clangPath));
     final sysroot = path.join(ndkToolchainRoot, 'sysroot');
@@ -95,6 +96,7 @@ interface class AndroidBuildEnvironmentFactory {
       'AR_$targetTripleEnvVar': path.fromUri(cCompiler.archiver),
       'CC_$targetTripleEnvVar': clangPath,
       'CXX_$targetTripleEnvVar': clangPpPath,
+      'RANLIB_$targetTripleEnvVar': ranlibPath,
       'CARGO_TARGET_${targetTripleEnvVar.toUpperCase()}_LINKER': clangPath,
       'BINDGEN_EXTRA_CLANG_ARGS_$targetTripleEnvVar': bindgenClangArgs,
     };


### PR DESCRIPTION
This introduces the `RANLIB_<target-triple>` environment variable during compilation, fixing errors encountered when compiling C code via Rust, which is required by OpenSSL.

NOTE: Cargokit does this as well see [here](https://github.com/irondash/cargokit/blob/ec49f0ee89744a8e80ee8df764bfb1faea95319b/build_tool/lib/src/android_environment.dart#L124-L125).