### PR TITLE
fix: do not include dep-info file itself as a tracked dependency

### DIFF
--- a/native_toolchain_rust/lib/src/dependency_discoverer.dart
+++ b/native_toolchain_rust/lib/src/dependency_discoverer.dart
@@ -10,14 +10,20 @@ interface class DependencyDiscoverer {
 
   final Logger logger;
 
-  /// Finds all the dependencies from the specified dependency file,
-  /// including the dependency file itself.
+  /// Finds all the source dependencies listed in the specified Cargo dep-info
+  /// file.
+  ///
+  /// The dep-info file itself is intentionally **not** included in the result:
+  /// Cargo refreshes its mtime on every invocation (even no-op rebuilds), which
+  /// causes Flutter's build graph to detect mid-build modifications and emit
+  /// `File modified during build. Build must be rerun.` warnings. The source
+  /// files parsed out of the dep-info already provide complete change-detection
+  /// coverage for incremental rebuilds.
   Iterable<Uri> discover(String dependencyFilePath) {
     logger.fine('Discovering dependencies in $dependencyFilePath');
     return File(dependencyFilePath)
         .readAsLinesSync()
         .expand((line) => line.trim().split(' ').skip(1))
-        .followedBy([dependencyFilePath])
         .map(path.toUri);
   }
 }

--- a/native_toolchain_rust/test/dependency_discoverer_test.dart
+++ b/native_toolchain_rust/test/dependency_discoverer_test.dart
@@ -29,10 +29,9 @@ void main() {
 
       expect(
         dependencies,
-        containsAll([
+        unorderedEquals([
           path.toUri('src/lib.rs'),
           path.toUri('/path/to/some/other/file.rs'),
-          path.toUri(dependencyFilePath),
         ]),
       );
     });
@@ -48,10 +47,9 @@ target/debug/librust_lib.a: /path/to/some/other/file.rs
 
       expect(
         dependencies,
-        containsAll([
+        unorderedEquals([
           path.toUri('src/lib.rs'),
           path.toUri('/path/to/some/other/file.rs'),
-          path.toUri(dependencyFilePath),
         ]),
       );
     });
@@ -62,14 +60,26 @@ target/debug/librust_lib.a: /path/to/some/other/file.rs
 
       final dependencies = dependencyDiscoverer.discover(dependencyFilePath);
 
-      expect(
-        dependencies,
-        containsAll([
-          path.toUri(dependencyFilePath),
-        ]),
-      );
-      expect(dependencies.length, 1);
+      expect(dependencies, isEmpty);
     });
+
+    test(
+      'discover does not include the dependency file itself',
+      () {
+        // Cargo refreshes the mtime of the dep-info file on every invocation,
+        // even for no-op rebuilds. Including it in the dependency list causes
+        // Flutter's build graph to emit "File modified during build. Build
+        // must be rerun." warnings. See issue #73.
+        final dependencyFilePath = path.join(tempDir.path, 'test.d');
+        File(dependencyFilePath).writeAsStringSync(
+          'target/debug/librust_lib.a: src/lib.rs',
+        );
+
+        final dependencies = dependencyDiscoverer.discover(dependencyFilePath);
+
+        expect(dependencies, isNot(contains(path.toUri(dependencyFilePath))));
+      },
+    );
 
     test(
       'discover throws an exception if the dependency file is not found',


### PR DESCRIPTION
Fixes #73.

## Problem

`DependencyDiscoverer.discover` appends the cargo-generated dep-info (`.d`) file to the list of dependencies it returns, in addition to the source files it parses out of that file:

```dart
return File(dependencyFilePath)
    .readAsLinesSync()
    .expand((line) => line.trim().split(' ').skip(1))
    .followedBy([dependencyFilePath]) // <-- self-reference
    .map(path.toUri);
```

Cargo refreshes the mtime of the `.d` file on **every** invocation, even no-op incremental rebuilds. Because Flutter's build graph hashes the inputs of every hook output and the hook is invoked multiple times per build (per ABI for Android, plus separate build/link passes), each successive invocation re-touches a `.d` mtime that downstream targets have already snapshotted. Flutter then emits `File modified during build. Build must be rerun.` and retries the pipeline.

In a representative reproducer (multi-ABI Android release APK), this manifests as 3 rerun warnings per build, matching 4 hook-cache directories (1 initial pass + 3 reruns).

## Fix

Drop the `.followedBy([dependencyFilePath])` self-reference. The source files parsed out of the dep-info already provide complete change-detection coverage — they're the actual compilation inputs cargo tracks — so dropping the dep-info file itself loses no information for incremental rebuilds. PR #44 / issue #43 remain fixed: the `discover` call still returns the parsed source URIs.

Doc comment updated to explain why the dep-info file is intentionally excluded.

## Tests

- Updated the three existing tests (`returns dependencies from a valid dependency file`, `handles multiple lines in the dependency file`, `handles an empty dependency file`) to no longer expect the dep-info file in the result. Switched their matchers from `containsAll(...)` to the stricter `unorderedEquals(...)` / `isEmpty` so a future regression that re-adds it would fail.
- Added a new `discover does not include the dependency file itself` regression test that explicitly asserts exclusion and references issue #73 in its comment.
- Existing exception test for missing files unchanged.

All 5 tests pass locally; `dart analyze` is clean.

```
00:00 +5: All tests passed!
```

## Notes

- This is the minimal, surgical fix discussed in #73. The optional "temp-file-then-atomic-rename" hardening for the cdylib artifact is **not** included here; it's a separate, larger change and not required to close this rerun loop, since the dep-info self-reference is the only path through which a cargo-touched mtime currently reaches Flutter's build graph.
- No public API change.
