### PR TITLE
fix: use lib.name instead of package.name if possible

### DIFF
--- a/native_toolchain_rust/lib/src/build_runner.dart
+++ b/native_toolchain_rust/lib/src/build_runner.dart
@@ -70,6 +70,7 @@ interface class RustBuildRunner {
     final outputDir = path.join(path.fromUri(input.outputDirectory), 'target');
     final manifestPath = path.join(crateDirectory.path, 'Cargo.toml');
     final (
+      :libName,
       :crateName,
       :toolchainChannel,
     ) = crateInfoValidator.fetchAndValidateCrateInfo(
@@ -114,7 +115,9 @@ interface class RustBuildRunner {
       outputDir,
       targetTriple,
       buildMode.name,
-      targetOS.libraryFileName(crateName, linkMode).replaceAll('-', '_'),
+      targetOS
+          .libraryFileName(libName ?? crateName, linkMode)
+          .replaceAll('-', '_'),
     );
 
     // NOTE: re-run build whenever any of the dependencies change

--- a/native_toolchain_rust/lib/src/crate_info_validator.dart
+++ b/native_toolchain_rust/lib/src/crate_info_validator.dart
@@ -12,17 +12,28 @@ interface class CrateInfoValidator {
   final ToolchainTomlParser toolchainTomlParser;
   final CargoManifestParser cargoManifestParser;
 
-  ({String crateName, String toolchainChannel}) fetchAndValidateCrateInfo({
+  ({String? libName, String crateName, String toolchainChannel})
+  fetchAndValidateCrateInfo({
     required String manifestPath,
     required String toolchainTomlPath,
     required String targetTriple,
   }) {
+    final manifest = cargoManifestParser.parseManifest(
+      manifestPath,
+    );
+
     final [
+      String? libName,
       String crateName,
       String toolchainChannel,
     ] = RustValidationException.compose<dynamic>([
+      () => manifest.libName,
       () {
-        final (:crateName, :libCrateTypes) = cargoManifestParser.parseManifest(
+        final CargoManifest(
+          :libName,
+          :crateName,
+          :libCrateTypes,
+        ) = cargoManifestParser.parseManifest(
           manifestPath,
         );
 
@@ -71,6 +82,10 @@ For more information, see https://github.com/GregoryConrad/native_toolchain_rust
       },
     ]);
 
-    return (crateName: crateName, toolchainChannel: toolchainChannel);
+    return (
+      libName: libName,
+      crateName: crateName,
+      toolchainChannel: toolchainChannel,
+    );
   }
 }

--- a/native_toolchain_rust/lib/src/toml_parsing.dart
+++ b/native_toolchain_rust/lib/src/toml_parsing.dart
@@ -6,6 +6,19 @@ import 'package:native_toolchain_rust/src/exception.dart';
 import 'package:toml/toml.dart';
 
 @internal
+class CargoManifest {
+  const CargoManifest({
+    required this.crateName,
+    required this.libCrateTypes,
+    this.libName,
+  });
+
+  final String? libName;
+  final String crateName;
+  final List<String> libCrateTypes;
+}
+
+@internal
 interface class TomlDocumentWrapperFactory {
   const TomlDocumentWrapperFactory(this.logger);
   final Logger logger;
@@ -53,7 +66,7 @@ interface class CargoManifestParser {
   final Logger logger;
   final TomlDocumentWrapperFactory tomlDocumentFactory;
 
-  ({String crateName, List<String> libCrateTypes}) parseManifest(
+  CargoManifest parseManifest(
     String manifestPath,
   ) {
     logger.info('Looking for Cargo.toml');
@@ -81,9 +94,19 @@ The following exception was thrown: $exception''',
     }
 
     final [
+      String? libName,
       String crateName,
       List<String> libCrateTypes,
     ] = RustValidationException.compose<dynamic>([
+      () {
+        try {
+          return manifest.walk<String>('lib.name');
+        } on RustValidationException {
+          logger.fine(
+            '`lib.name` is not defined. Using `package.name` instead',
+          );
+        }
+      },
       () {
         try {
           return manifest.walk<String>('package.name');
@@ -109,7 +132,11 @@ and https://doc.rust-lang.org/cargo/reference/cargo-targets.html#the-crate-type-
       },
     ]);
 
-    return (crateName: crateName, libCrateTypes: libCrateTypes);
+    return CargoManifest(
+      libName: libName,
+      crateName: crateName,
+      libCrateTypes: libCrateTypes,
+    );
   }
 }
 

--- a/native_toolchain_rust/test/crate_info_validator_test.dart
+++ b/native_toolchain_rust/test/crate_info_validator_test.dart
@@ -24,10 +24,12 @@ void main() {
     });
 
     test('fetchAndValidateCrateInfo returns correct info on success', () {
-      when(() => mockCargoManifestParser.parseManifest(any())).thenReturn((
-        crateName: 'my_crate',
-        libCrateTypes: ['staticlib', 'cdylib'],
-      ));
+      when(() => mockCargoManifestParser.parseManifest(any())).thenReturn(
+        const CargoManifest(
+          crateName: 'my_crate',
+          libCrateTypes: ['staticlib', 'cdylib'],
+        ),
+      );
       when(() => mockToolchainTomlParser.parseToolchainToml(any())).thenReturn((
         channel: '1.90.0',
         targets: {'aarch64-linux-android'},
@@ -44,10 +46,12 @@ void main() {
     });
 
     test('fetchAndValidateCrateInfo throws exception on validation issues', () {
-      when(() => mockCargoManifestParser.parseManifest(any())).thenReturn((
-        crateName: 'my_crate',
-        libCrateTypes: ['staticlib'],
-      ));
+      when(() => mockCargoManifestParser.parseManifest(any())).thenReturn(
+        const CargoManifest(
+          crateName: 'my_crate',
+          libCrateTypes: ['staticlib'],
+        ),
+      );
       when(() => mockToolchainTomlParser.parseToolchainToml(any())).thenReturn((
         channel: 'stable',
         targets: {'x86_64-linux-gnu'},


### PR DESCRIPTION
when rust compiles the library, and lib.name is defined, the pattern lib{lib.name}.d is used instead of lib{package.name}.d, So this PR covers this.

Previous to this PR, this wouldn't compile

```toml
[package]
name = "anb-sys"
version = "0.1.0"
edition = "2024"

[dependencies]
anb = { path = "../anb" }

[build-dependencies]
cbindgen = "0.29.4"

[lib]
name = "anb"
crate-type = ["cdylib", "staticlib"]
```
 Solves #97