### PR TITLE
fix: resolve rustup from HOME when not in PATH

### DIFF
--- a/native_toolchain_rust/lib/src/process_runner.dart
+++ b/native_toolchain_rust/lib/src/process_runner.dart
@@ -53,7 +53,9 @@ extension InvokeRustup on ProcessRunner {
     String? workingDirectory,
     Map<String, String>? environment,
   }) async {
-    late ProcessException lastException;
+    final failureReasons = <String>[];
+    ProcessException? firstFailure;
+
     for (final executable in _rustupExecutables) {
       try {
         return await invoke(
@@ -63,15 +65,16 @@ extension InvokeRustup on ProcessRunner {
           environment: environment,
         );
       } on ProcessException catch (e) {
-        lastException = e;
+        firstFailure ??= e;
+        failureReasons.add('"$executable" (${e.message})');
       }
     }
 
     throw RustProcessException(
       'Failed to invoke rustup; is it installed? '
-      'Checked the following paths: $_rustupExecutables. '
+      'Tried ${failureReasons.join(', ')}. '
       'For help installing rust, see https://rustup.rs',
-      inner: lastException,
+      inner: firstFailure,
     );
   }
 }

--- a/native_toolchain_rust/lib/src/process_runner.dart
+++ b/native_toolchain_rust/lib/src/process_runner.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:logging/logging.dart';
 import 'package:meta/meta.dart';
 import 'package:native_toolchain_rust/src/exception.dart';
+import 'package:path/path.dart' as path;
 
 @internal
 interface class ProcessRunner {
@@ -35,7 +36,7 @@ interface class ProcessRunner {
       }
       return result.stdout as String;
     } on ProcessException catch (exception, stackTrace) {
-      logger.severe(
+      logger.info(
         'Failed to invoke "$executable $arguments"',
         exception,
         stackTrace,
@@ -52,19 +53,40 @@ extension InvokeRustup on ProcessRunner {
     String? workingDirectory,
     Map<String, String>? environment,
   }) async {
-    try {
-      return await invoke(
-        'rustup',
-        arguments,
-        workingDirectory: workingDirectory,
-        environment: environment,
-      );
-    } on ProcessException catch (e) {
-      throw RustProcessException(
-        'Failed to invoke rustup; is it installed? '
-        'For help installing rust, see https://rustup.rs',
-        inner: e,
-      );
+    late ProcessException lastException;
+    for (final executable in _rustupExecutables) {
+      try {
+        return await invoke(
+          executable,
+          arguments,
+          workingDirectory: workingDirectory,
+          environment: environment,
+        );
+      } on ProcessException catch (e) {
+        lastException = e;
+      }
     }
+
+    throw RustProcessException(
+      'Failed to invoke rustup; is it installed? '
+      'Checked the following paths: $_rustupExecutables. '
+      'For help installing rust, see https://rustup.rs',
+      inner: lastException,
+    );
   }
+}
+
+/// `rustup` executables to attempt to launch, in order of preference
+///
+/// Defaults to `rustup` lookup via PATH, followed by `~/.cargo/bin/rustup`
+List<String> get _rustupExecutables {
+  final homeDirectory = Platform.isWindows
+      ? Platform.environment['USERPROFILE']
+      : Platform.environment['HOME'];
+
+  return [
+    'rustup',
+    if (homeDirectory != null)
+      path.join(homeDirectory, '.cargo', 'bin', 'rustup'),
+  ];
 }


### PR DESCRIPTION
Fixes #95

I couldn't come up with a nice way to test this due to how Dart restricts environment mutation for tests. If you want me to add tests, let me know.