### PR TITLE
fix: don't throw error when lib.name is null

### DIFF
--- a/native_toolchain_rust/lib/src/toml_parsing.dart
+++ b/native_toolchain_rust/lib/src/toml_parsing.dart
@@ -100,7 +100,7 @@ The following exception was thrown: $exception''',
     ] = RustValidationException.compose<dynamic>([
       () {
         try {
-          return manifest.walk<String>('lib.name');
+          return manifest.walk<String?>('lib.name');
         } on RustValidationException {
           logger.fine(
             '`lib.name` is not defined. Using `package.name` instead',

--- a/native_toolchain_rust/test/toml_parsing_test.dart
+++ b/native_toolchain_rust/test/toml_parsing_test.dart
@@ -67,6 +67,7 @@ crate-type = ["staticlib"]
 
       expect(result.crateName, 'my_crate');
       expect(result.libCrateTypes, ['staticlib']);
+      expect(result.libName, isNull);
     });
 
     test('parseManifest throws when Cargo.toml not found', () {


### PR DESCRIPTION
Fixes https://github.com/GregoryConrad/native_toolchain_rust/issues/103

I can't reproduce the error in the unit tests, but it does fix it in my real app:
```console
Building Linux application...
✓ Built build/linux/x64/release/bundle/saber
ahann@dellpro:~/Documents/GitHub/saber$ flutter build linux # without this patch
ERROR: [SEVERE] RustBuilder: Failed to find lib.name in /home/ahann/.pub-cache/hosted/pub.dev/super_native_extensions-0.10.0-dev.2/rust/Cargo.toml: [workspace]
ERROR: [SEVERE] RustBuilder: Failed to find lib.name in /home/ahann/.pub-cache/hosted/pub.dev/super_native_extensions-0.10.0-dev.2/rust/Cargo.toml: [workspace]
Building Linux application...                                           
✓ Built build/linux/x64/release/bundle/saber
ahann@dellpro:~/Documents/GitHub/saber$ flutter build linux # with this patch
Building Linux application...                                           
✓ Built build/linux/x64/release/bundle/saber
ahann@dellpro:~/Documents/GitHub/saber$ 
```