### PR TITLE
test: don't throw error when lib.name is null

### DIFF
--- a/native_toolchain_rust/test/toml_parsing_test.dart
+++ b/native_toolchain_rust/test/toml_parsing_test.dart
@@ -80,7 +80,9 @@ name = "my_crate"
 crate-type = ["staticlib"]
 ''');
 
+      var hasLogged = false;
       final subscription = logger.onRecord.listen((record) {
+        hasLogged = true;
         expect(record.level, lessThan(Level.SEVERE));
       });
       addTearDown(subscription.cancel);
@@ -90,6 +92,7 @@ crate-type = ["staticlib"]
       expect(result.crateName, 'my_crate');
       expect(result.libCrateTypes, ['staticlib']);
       expect(result.libName, isNull);
+      expect(hasLogged, isTrue);
     });
 
     test('parseManifest throws when Cargo.toml not found', () {

--- a/native_toolchain_rust/test/toml_parsing_test.dart
+++ b/native_toolchain_rust/test/toml_parsing_test.dart
@@ -54,7 +54,24 @@ void main() {
       tempDir.deleteSync(recursive: true);
     });
 
-    test('parseManifest returns crate name and lib crate types', () {
+    test('parseManifest returns crate/lib name and lib crate types', () {
+      File(tempManifestPath).writeAsStringSync('''
+[package]
+name = "my_crate"
+
+[lib]
+name = "my_lib"
+crate-type = ["staticlib"]
+''');
+
+      final result = parser.parseManifest(tempManifestPath);
+
+      expect(result.crateName, 'my_crate');
+      expect(result.libCrateTypes, ['staticlib']);
+      expect(result.libName, 'my_lib');
+    });
+
+    test('parseManifest does not log error if lib.name missing', () {
       File(tempManifestPath).writeAsStringSync('''
 [package]
 name = "my_crate"
@@ -62,6 +79,11 @@ name = "my_crate"
 [lib]
 crate-type = ["staticlib"]
 ''');
+
+      final subscription = logger.onRecord.listen((record) {
+        expect(record.level, lessThan(Level.SEVERE));
+      });
+      addTearDown(subscription.cancel);
 
       final result = parser.parseManifest(tempManifestPath);
 


### PR DESCRIPTION
Adds a unit test that reproduces #103 